### PR TITLE
Bump to 0.04

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+.PHONY: quality style clean release beta
+
+check_dirs := wordwise
+
+quality: # Check that source code meets quality standards
+	black --check $(check_dirs)
+	isort --check-only $(check_dirs)
+	flake8 $(check_dirs) --max-line-length 119
+
+style: # Format source code automatically
+	black $(check_dirs)
+	isort $(check_dirs)
+
+clean:
+	rm -r build dist wordwise.egg-info
+
+release:
+	python setup.py sdist bdist_wheel
+
+beta:
+	twine upload --repository-url https://test.pypi.org/legacy/ dist/*

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+black
+isort
+flake8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pytorch==1.6.0
+torch==1.6.0
 transformers===3.5.1
 scikit-learn==0.23.2
 spacy==2.3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-torch==1.6.0
-transformers===3.5.1
-scikit-learn==0.23.2
-spacy==2.3.2
+transformers
+torch
+scikit-learn
+spacy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 transformers>=3.5.1
-torch>=1.6
+torch>=1.6.0
 scikit-learn>=0.23.2
 spacy>=2.3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-transformers
-torch
-scikit-learn
-spacy
+transformers>=3.5.1
+torch>=1.6
+scikit-learn>=0.23.2
+spacy>=2.3.2

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,9 @@ from setuptools import find_packages, setup
 with open("README.md", "r") as f:
     long_description = f.read()
 
+with open("requirements.txt", "r") as f:
+    requirements = f.read().splitlines()
+
 setup(
     name="wordwise",
     version="0.0.4",
@@ -22,5 +25,5 @@ setup(
         "Operating System :: OS Independent",
     ],
     python_requires=">=3.6",
-    install_requires=["transformers", "spacy", "scikit-learn"],
+    install_requires=requirements,
 )

--- a/wordwise/__init__.py
+++ b/wordwise/__init__.py
@@ -1,2 +1,1 @@
-import wordwise.utils
 from wordwise.core import Extractor

--- a/wordwise/__init__.py
+++ b/wordwise/__init__.py
@@ -1,1 +1,1 @@
-from wordwise.core import Extractor
+from wordwise.core import Extractor  # noqa: F401

--- a/wordwise/core.py
+++ b/wordwise/core.py
@@ -4,8 +4,8 @@ import spacy
 import torch
 from sklearn.metrics.pairwise import cosine_similarity
 from transformers import AutoModel, AutoTokenizer
-from .utils import get_all_candidates, squash
 
+from .utils import get_all_candidates, squash
 
 logger = logging.getLogger(__name__)
 
@@ -22,7 +22,7 @@ class Extractor:
             self.nlp = spacy.load(spacy_model)
         except OSError:
             logger.error(
-                f"Can't find spaCy model {spacy_model}.\n"\
+                f"Can't find spaCy model {spacy_model}.\n"
                 f"Have you run `python -m spacy download {spacy_model}`?"
             )
             raise
@@ -70,10 +70,9 @@ class Extractor:
             value = tuple(outputs.values())[0]
         else:
             for key in ["pooler_output", "last_hidden_state"]:
-                if key in output_keys:
+                if key in outputs_keys:
                     value = outputs[key]
                     break
         if value is None:
             raise RuntimeError("no matching BERT keys found for `outputs`")
         return squash(value)
-

--- a/wordwise/core.py
+++ b/wordwise/core.py
@@ -1,8 +1,13 @@
+import logging
+
 import spacy
 import torch
 from sklearn.metrics.pairwise import cosine_similarity
 from transformers import AutoModel, AutoTokenizer
-from wordwise.utils import get_all_candidates, squash
+from .utils import get_all_candidates, squash
+
+
+logger = logging.getLogger(__name__)
 
 
 class Extractor:
@@ -13,7 +18,14 @@ class Extractor:
         bert_model="sentence-transformers/distilbert-base-nli-stsb-mean-tokens",
     ):
         self.n_gram_range = n_gram_range
-        self.nlp = spacy.load(spacy_model)
+        try:
+            self.nlp = spacy.load(spacy_model)
+        except OSError:
+            logger.error(
+                f"Can't find spaCy model {spacy_model}.\n"\
+                f"Have you run `python -m spacy download {spacy_model}`?"
+            )
+            raise
         self.model = AutoModel.from_pretrained(bert_model)
         self.tokenizer = AutoTokenizer.from_pretrained(bert_model)
 


### PR DESCRIPTION
This PR bumps the project version to 0.0.4, with the following changes:

1. A more informative message is invoked when spaCy models are not installed
2. Required package versions are made more flexible via `>=`
3. Fix one minor variable name typo
4. Various `core`-related import errors are fixed