### PR TITLE
Update BERT model

### DIFF
--- a/wordwise/core.py
+++ b/wordwise/core.py
@@ -15,7 +15,7 @@ class Extractor:
         self,
         n_gram_range=(1, 2),
         spacy_model="en_core_web_sm",
-        bert_model="sentence-transformers/all-MiniLM-L6-v2",
+        bert_model="sentence-transformers/all-MiniLM-L12-v2",
     ):
         self.n_gram_range = n_gram_range
         try:


### PR DESCRIPTION
# Context
The [default Sentence-BERT model](https://huggingface.co/sentence-transformers/distilbert-base-nli-stsb-mean-tokens) used by the `Extractor` class is deprecated.

After some exploring, I found that a good alternative model is [`sentence-transformers/all-MiniLM-L6-v2`](https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2). The embedding space dimension is half that of the previous default `sentence-transformers/distilbert-base-nli-stsb-mean-tokens`, which makes it significantly faster.

The top performing Sentence-BERT model ([according to Sentence Transformers](https://www.sbert.net/docs/pretrained_models.html)) is [`sentence-transformers/all-mpnet-base-v2`](https://huggingface.co/sentence-transformers/all-mpnet-base-v2), which could be used instead. Note, however, that runtime is 5 times longer than `sentence-transformers/all-MiniLM-L6-v2`.

# Contribution
This PR changes the default BERT model to `sentence-transformers/all-MiniLM-L6-v2`.