### PR TITLE
Truncate tokenization

### DIFF
--- a/wordwise/core.py
+++ b/wordwise/core.py
@@ -57,7 +57,13 @@ class Extractor:
     def get_embedding(self, source):
         if isinstance(source, str):
             source = [source]
-        tokens = self.tokenizer(source, padding=True, return_tensors="pt")
+        tokens = self.tokenizer(
+            source,
+            padding=True,
+            truncation=True,
+            max_length=self.tokenizer.model_max_length,
+            return_tensors="pt",
+        )
         outputs = self.model(**tokens, return_dict=True)
         embedding = self.parse_outputs(outputs)
         embedding = embedding.detach().numpy()


### PR DESCRIPTION
# Context
As [discussed in this issue](https://github.com/jaketae/wordwise/issues/4#issuecomment-905829488), an `IndexError` can be raised if too many tokens are passed to the BERT model at once. One initial solution is to truncate the tokenized output to the maximum sequence length.

# Contribution
Truncated the tokenized output. I think the `tokenizer` will automatically truncate to the max length of the  associated BERT model, but for clarity (and to allow users to look this up within the code) we can also get the max length from the attribute  `self.tokenizer.model_max_length`.