### PR TITLE
Use `torch.inference_mode` if possible

### DIFF
--- a/wordwise/core.py
+++ b/wordwise/core.py
@@ -5,7 +5,7 @@ import torch
 from torch.nn import functional as F
 from transformers import AutoModel, AutoTokenizer
 
-from .utils import get_all_candidates, squash
+from .utils import get_all_candidates, squash, torch_fast_mode
 
 logger = logging.getLogger(__name__)
 
@@ -59,7 +59,7 @@ class Extractor:
         noun_phrases = set(chunk.text.strip() for chunk in doc.noun_chunks)
         return nouns.union(noun_phrases)
 
-    @torch.no_grad()
+    @torch_fast_mode()
     def get_embedding(self, source):
         if isinstance(source, str):
             source = [source]

--- a/wordwise/utils.py
+++ b/wordwise/utils.py
@@ -14,3 +14,11 @@ def get_all_candidates(text, n_gram_range):
     count = CountVectorizer(ngram_range=n_gram_range, stop_words="english").fit([text])
     all_candidates = count.get_feature_names_out()
     return all_candidates
+
+
+def torch_fast_mode():
+    """use `torch.inference_mode()` if torch version is high enough"""
+    try:
+        return torch.inference_mode()
+    except AttributeError:
+        return torch.no_grad()


### PR DESCRIPTION
PyTorch 1.9 and higher supports a new `inference_mode`, which is even more optimized for performance than `torch.no_grad()`. Check if inference mode is available and use if possible.